### PR TITLE
updated for the new http_client interface (Python 3.4.3)

### DIFF
--- a/api/bcrpc.py
+++ b/api/bcrpc.py
@@ -44,7 +44,7 @@ def passthrough(webui, httprequest, path, privileges):
     "Content-Length": length,
   }
   try:
-    conn = http_client.HTTPConnection(webui.config.rpchost, webui.config.rpcport, True, 10)
+    conn = http_client.HTTPConnection(webui.config.rpchost, webui.config.rpcport, timeout=10)
     conn.request("POST", webui.config.rpcpath, data, headers)
     response = conn.getresponse()
     contenttype = response.getheader("content-type")


### PR DESCRIPTION
I think the interface to the http_client.HTTPConnection have changed since you made it. The new signature for conn = http_client.HTTPConnection() is 
`http.client.HTTPConnection(host, port=None, [timeout, ]source_address=None)`
See the [Python 3 documentation](https://docs.python.org/3/library/http.client.html#http.client.HTTPConnection).

I've only tested it briefly, and only on Python 3.4.3 - so you might want to do some testing yourself to ensure backward compatibility.
